### PR TITLE
Fix compilation errors seen with MSVC

### DIFF
--- a/include/boost/program_options/detail/config_file.hpp
+++ b/include/boost/program_options/detail/config_file.hpp
@@ -27,6 +27,11 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/shared_ptr.hpp>
 
+#ifdef BOOST_MSVC
+# pragma warning(push)
+# pragma warning(disable: 4251) // class XYZ needs to have dll-interface to be used by clients of class XYZ
+#endif
+
 
 
 namespace boost { namespace program_options { namespace detail {
@@ -77,6 +82,11 @@ namespace boost { namespace program_options { namespace detail {
         
         void get();
         
+#if BOOST_WORKAROUND(_MSC_VER, <= 1800)
+        void decrement() {}
+        void advance(difference_type) {}
+#endif
+
     protected: // Stubs for derived classes
 
         // Obtains next line from the config file
@@ -176,5 +186,9 @@ namespace boost { namespace program_options { namespace detail {
     
 
 }}}
+
+#ifdef BOOST_MSVC
+# pragma warning(pop)
+#endif
 
 #endif


### PR DESCRIPTION
Previous fix 4ae33ce for ticket #6797 introduced a new problem with Visual Studio compilers about two missing methods in 'common_config_file_iterator'. Adding those seemingly not required methods as empty methods fixes the issue. As an added bonus, the bogus warnings about DLL-interfaces get a silencing treatment, too.

Tests were run with vc10, vc11, and vc12. Without this fix, the affected test cases fail on all 3 compilers. With the fix in place, all tests pass.

Signed-off-by: Daniela Engert dani@ngrt.de
