### PR TITLE
get rid of as many level-4 warnings as possible (qoi)

### DIFF
--- a/include/boost/program_options/options_description.hpp
+++ b/include/boost/program_options/options_description.hpp
@@ -236,6 +236,11 @@ namespace program_options {
         void print(std::ostream& os, unsigned width = 0) const;
 
     private:
+#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1800))
+        // prevent warning C4512: assignment operator could not be generated
+        options_description& operator=(const options_description&);
+#endif
+
         typedef std::map<std::string, int>::const_iterator name2index_iterator;
         typedef std::pair<name2index_iterator, name2index_iterator> 
             approximation_range;

--- a/src/parsers.cpp
+++ b/src/parsers.cpp
@@ -220,7 +220,7 @@ namespace boost { namespace program_options {
                     {   
                         // Intel-Win-7.1 does not understand
             // push_back on string.         
-                        result += tolower(s[n]);
+                        result += static_cast<char>(tolower(s[n]));
                     }
                 }
                 return result;

--- a/src/value_semantic.cpp
+++ b/src/value_semantic.cpp
@@ -268,7 +268,12 @@ namespace boost { namespace program_options {
 
     void error_with_option_name::replace_token(const string& from, const string& to) const
     {
+#if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1800))
+// prevent warning C4127: conditional expression is constant
+        for (;;)
+#else		
         while (1)
+#endif		
         {
             std::size_t pos = m_message.find(from.c_str(), 0, from.length());
             // not found: all replaced


### PR DESCRIPTION
Even when compiled at warning level 4 (i.e. all), project policies may require compilations without warnings issued.

Signed-off-by: Daniela Engert dani@ngrt.de
