### PR TITLE
Changes for ticket #10718

### DIFF
--- a/include/boost/program_options/value_semantic.hpp
+++ b/include/boost/program_options/value_semantic.hpp
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 #include <typeinfo>
-#include <limit>
+#include <limits>
 
 namespace boost { namespace program_options {
 


### PR DESCRIPTION
I used std::numeric_limits<unsigned>::max(); instead of UINT_MAX from <climits> as originally proposed as this is the C++ way of doing this.
