### PR TITLE
Ticket #4510: implicit_value and positional options conflict

### DIFF
--- a/include/boost/program_options/value_semantic.hpp
+++ b/include/boost/program_options/value_semantic.hpp
@@ -49,7 +49,11 @@ namespace boost { namespace program_options {
 
         */
         virtual bool is_required() const = 0;
-        
+
+        /** Returns true if has an implicit value
+        */
+        virtual bool has_implicit_value() const = 0;
+
         /** Parses a group of tokens that specify a value of option.
             Stores the result in 'value_store', using whatever representation
             is desired. May be be called several times if value of the same
@@ -139,6 +143,8 @@ namespace boost { namespace program_options {
         bool is_composing() const { return false; }
 
         bool is_required() const { return false; }
+
+        bool has_implicit_value() const { return false; }
         
         /** If 'value_store' is already initialized, or new_tokens
             has more than one elements, throws. Otherwise, assigns
@@ -323,6 +329,8 @@ namespace boost { namespace program_options {
         }
 
         bool is_required() const { return m_required; }
+
+        bool has_implicit_value() const { return !m_implicit_value.empty(); }
 
         /** Creates an instance of the 'validator' class and calls
             its operator() to perform the actual conversion. */

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -313,6 +313,9 @@ namespace boost { namespace program_options { namespace detail {
             if (!xd)
                 continue;
 
+            if(xd->semantic()->has_implicit_value())
+                continue;
+
             unsigned min_tokens = xd->semantic()->min_tokens();
             unsigned max_tokens = xd->semantic()->max_tokens();
             if (min_tokens < max_tokens && opt.value.size() < max_tokens)


### PR DESCRIPTION
Add a has_implicit_value method to check if an implicit_value was set.  This is used to avoid processing positional arguments for options with implicit_value.

The change seems simple enough, however, I am not nearly as familiar with the library, and I could not build this using the git repo to test it, as there seems to be some problem with building all the boost libraries on the main git repo.  However, I did test it by applying the changes to the latest release of boost (1.57.0) and it seems to work fine.
