### PR TITLE
Add testing for implicit_values and non-consuming of separate tokens.

### DIFF
--- a/test/cmdline_test.cpp
+++ b/test/cmdline_test.cpp
@@ -63,7 +63,8 @@ struct test_case {
    The "boost::program_options" in parameter type is needed because CW9 
    has std::detail and it causes an ambiguity.
 */
-void apply_syntax(options_description& desc, 
+void apply_syntax(options_description& desc,
+                  positional_options_description & m_positional,
                   const char* syntax)
 {
    
@@ -77,8 +78,8 @@ void apply_syntax(options_description& desc,
             v = value<string>();
             s.resize(s.size()-1);
         } else if (*(s.end()-1) == '?') {
-            //v = value<string>()->implicit();
-            v = value<string>();
+            v = value<string>()->implicit_value("bar");
+            m_positional.add("positional", -1);
             s.resize(s.size()-1);
         } else if (*(s.end()-1) == '*') {
             v = value<vector<string> >()->multitoken();
@@ -113,12 +114,14 @@ void test_cmdline(const char* syntax,
             }
         }
         options_description desc;
-        apply_syntax(desc, syntax);
+        positional_options_description m_positional;
+        apply_syntax(desc, m_positional, syntax);
 
         cmdline cmd(xinput);
         cmd.style(style);
         cmd.set_options_description(desc);
-
+        if(m_positional.max_total_count())
+            cmd.set_positional_options(m_positional);
 
         string result;
         int status = 0;
@@ -130,7 +133,9 @@ void test_cmdline(const char* syntax,
             {
                 option opt = options[j];
 
-                if (opt.position_key != -1) {
+                if (opt.position_key != -1
+                    && (m_positional.max_total_count() == 0 || opt.position_key >= m_positional.max_total_count()
+                     || m_positional.name_for_position(opt.position_key) != "positional")) {
                     if (!result.empty())
                         result += " ";
                     result += opt.value[0];
@@ -228,7 +233,7 @@ void test_long_options()
         {"--giz", s_success, "Giz:"},
         {0, 0, 0}
     };
-    test_cmdline("foo bar= baz? Giz", style, test_cases4);
+    test_cmdline("foo bar= Giz", style, test_cases4);
 }
 
 void test_short_options()
@@ -348,7 +353,7 @@ void test_disguised_long()
         {"-bee=x -by", s_success, "bee:x bee:y"},
         {0, 0, 0}
     };
-    test_cmdline("foo,f goo,g= bee,b?", style, test_cases1);
+    test_cmdline("foo,f goo,g= bee,b=", style, test_cases1);
 
     style = cmdline::style_t(style | allow_slash_for_short);
     test_case test_cases2[] = {
@@ -356,7 +361,7 @@ void test_disguised_long()
         {"/goo=x", s_success, "goo:x"},
         {0, 0, 0}
     };
-    test_cmdline("foo,f goo,g= bee,b?", style, test_cases2);
+    test_cmdline("foo,f goo,g=", style, test_cases2);
 }
 
 void test_guessing()
@@ -607,6 +612,35 @@ void test_unregistered()
     // It's not clear yet, so I'm leaving the decision till later.
 }
 
+void test_implicit_value()
+{
+    using namespace command_line_style;
+    cmdline::style_t style;
+
+    style = cmdline::style_t(
+        allow_long | long_allow_adjacent
+        );
+
+    test_case test_cases1[] = {
+        {"--foo bar", s_success, "foo: positional:bar"},
+        {"--foo=bar foobar", s_success, "foo:bar positional:foobar"},
+        {0, 0, 0}
+    };
+
+    test_cmdline("positional= foo?", style, test_cases1);
+
+    style = cmdline::style_t(
+        allow_short | allow_dash_for_short 
+        | short_allow_adjacent);
+
+    test_case test_cases2[] = {
+        {"-f bar", s_success, "-f: positional:bar"},
+        {"-fbar foobar", s_success, "-f:bar positional:foobar"},
+        {0, 0, 0}
+    };
+    test_cmdline("positional= ,f?", style, test_cases2);
+}
+
 int main(int /*ac*/, char** /*av*/)
 {
     test_long_options();
@@ -619,6 +653,7 @@ int main(int /*ac*/, char** /*av*/)
     test_additional_parser();
     test_style_parser();
     test_unregistered();
+    test_implicit_value();
 
     return 0;
 }


### PR DESCRIPTION
The testing did not really provide support for implicit_values or positional arguments.  So, I added this.

Instead of introducing a new character for the syntax and since `?` and `=` had the same meaning, I changed `?` to be used for implicit_values (as in regular expressions it is 0 or 1).  All previous uses of `?` were changed to `=`.

To make sure that positional arguments were not being consumed, positional_object_description is set up only for implicit_values.  The test_cmd code also needed to be slightly modified so positional arguments were taken as part of the previous option as position != -1.

Feel free to change anything.
