### PR TITLE
Protect against max macro

### DIFF
--- a/include/boost/program_options/value_semantic.hpp
+++ b/include/boost/program_options/value_semantic.hpp
@@ -320,7 +320,7 @@ namespace boost { namespace program_options {
 
         unsigned max_tokens() const {
             if (m_multitoken) {
-                return std::numeric_limits<unsigned>::max();
+                return std::numeric_limits<unsigned>::max BOOST_PREVENT_MACRO_SUBSTITUTION();
             } else if (m_zero_tokens) {
                 return 0;
             } else {


### PR DESCRIPTION
This fixes compilation for MSVC in the case when NOMINMAX is not defined and the program_options include appears after the windows.h include.