### PR TITLE
Explicitly initialize m_implicit

### DIFF
--- a/include/boost/program_options/value_semantic.hpp
+++ b/include/boost/program_options/value_semantic.hpp
@@ -191,8 +191,8 @@ namespace boost { namespace program_options {
             the value when it's known. The parameter can be NULL. */
         typed_value(T* store_to) 
         : m_store_to(store_to), m_composing(false),
-          m_multitoken(false), m_zero_tokens(false),
-          m_required(false)
+          m_implicit(false), m_multitoken(false),
+          m_zero_tokens(false), m_required(false)
         {} 
 
         /** Specifies default value, which will be used


### PR DESCRIPTION
m_implicit was previously uninitialized in this constructor, leading to possibly inconsistent functionality. Instead, we now initialize it to false. This issue is related to Coverity CID10559 and was uncovered by Coverity.