### PR TITLE
Value-initialize m_desc

### DIFF
--- a/include/boost/program_options/detail/parsers.hpp
+++ b/include/boost/program_options/detail/parsers.hpp
@@ -40,7 +40,8 @@ namespace boost { namespace program_options {
     : detail::cmdline(
         // Explicit template arguments are required by gcc 3.3.1 
         // (at least mingw version), and do no harm on other compilers.
-        to_internal(detail::make_vector<charT, const charT* const*>(argv+1, argv+argc+!argc)))
+        to_internal(detail::make_vector<charT, const charT* const*>(argv+1, argv+argc+!argc))),
+        m_desc()
     {}
 
     


### PR DESCRIPTION
Value-initialize m_desc (to NULL) in this constructor to avoid uninitialized memory situations. This issue is related to Coverity CID12523 and was uncovered by Coverity.