### PR TITLE
get_option_name() can throw std::logic_error

### DIFF
--- a/include/boost/program_options/errors.hpp
+++ b/include/boost/program_options/errors.hpp
@@ -169,7 +169,7 @@ namespace boost { namespace program_options {
         virtual void set_option_name(const std::string& option_name)
         {           set_substitute("option", option_name);}
 
-        std::string get_option_name() const throw()
+        std::string get_option_name() const
         {           return get_canonical_option_name();         }
 
         void set_original_token(const std::string& original_token)


### PR DESCRIPTION
get_option_name()  calls get_canonical_option_prefix()  which throws in file value_semantic.cpp line no 296

296             throw std::logic_error("error_with_option_name::m_option_style can only be " 
297                               "one of [0, allow_dash_for_short, allow_slash_for_short, " 
298                               "allow_long_disguise or allow_long]"); 
299    }