### PR TITLE
Add try catch for get_canonical_option_name()

### DIFF
--- a/include/boost/program_options/errors.hpp
+++ b/include/boost/program_options/errors.hpp
@@ -170,7 +170,15 @@ namespace boost { namespace program_options {
         {           set_substitute("option", option_name);}
 
         std::string get_option_name() const
-        {           return get_canonical_option_name();         }
+        {           
+        	try
+        	{
+        	return get_canonical_option_name();
+        	}
+        	catch(...)
+        	{
+        	}
+        }
 
         void set_original_token(const std::string& original_token)
         {           set_substitute("original_token", original_token);}

--- a/src/value_semantic.cpp
+++ b/src/value_semantic.cpp
@@ -325,8 +325,14 @@ namespace boost { namespace program_options {
     {
         m_message = error_template;
         std::map<std::string, std::string> substitutions(m_substitutions);
+        try
+        {
         substitutions["canonical_option"]   = get_canonical_option_name();
         substitutions["prefix"]             = get_canonical_option_prefix();
+        }
+        catch(...)
+        {
+        }
 
 
         //


### PR DESCRIPTION
get_canonical_option_name() throws internally as get_canonical_option_prefix() throws as below:
296         throw std::logic_error("error_with_option_name::m_option_style can only be "
297                                "one of [0, allow_dash_for_short, allow_slash_for_short, "
298                                "allow_long_disguise or allow_long]");
299 
So add try - catch block to disable error reported by static analyzer tool.
