### PR TITLE
Support boost::optional option variables.

### DIFF
--- a/doc/howto.xml
+++ b/doc/howto.xml
@@ -435,6 +435,58 @@ vector&lt;string&gt; to_pass_further = collect_unrecognized(parsed.options, incl
 
     </section>
 
+    <section>
+      <title>Testing Option Presence</title>
+
+      <para>Until now we have tested whether an option has been set using the
+      <methodname alt="boost::program_options::variables_map::count">count</methodname> method on the &variables_map;
+      class; as you are repeating the (string literal) name of the option this is prone to typos and/or errors
+      resulting from renaming the option in one place but not the other:
+        <programlisting><![CDATA[
+po::options_description desc("Allowed options");
+desc.add_options()
+    ("compression", po::value<int>(), "set compression level")
+;
+
+po::variables_map vm;
+po::store(po::parse_command_line(ac, av, desc), vm);
+po::notify(vm);
+
+if (vm.count("compression")) {
+    cout << "Compression level was set to "
+ << vm["compression"].as<int>() << ".\n";
+} else {
+    cout << "Compression level was not set.\n";
+}
+]]>
+        </programlisting>
+      </para>
+
+      <para>Instead, you can use a variable of type <classname alt="boost::optional">boost::optional</classname>;
+      <libraryname>Program_options</libraryname> provides special support for <libraryname>Boost.Optional</libraryname>
+      such that if the user specifies the option the <classname alt="boost::optional">boost::optional</classname>
+      variable will be initialized to the appropriate value:
+        <programlisting><![CDATA[
+po::options_description desc("Allowed options");
+boost::optional<int> compression;
+desc.add_options()
+    ("compression", po::value(&compression), "set compression level")
+;
+
+po::variables_map vm;
+po::store(po::parse_command_line(ac, av, desc), vm);
+po::notify(vm);
+
+if (compression)) {
+    cout << "Compression level was set to " << *compression << ".\n";
+} else {
+    cout << "Compression level was not set.\n";
+}
+]]>
+        </programlisting>
+      </para>
+    </section>
+
 </section>
 
 <!--

--- a/doc/post_review_plan.txt
+++ b/doc/post_review_plan.txt
@@ -178,5 +178,4 @@
         
 12. Deferred 
 
-   - storing value to boost::optional 
    - setting a flag when option is found 

--- a/include/boost/program_options/detail/value_semantic.hpp
+++ b/include/boost/program_options/detail/value_semantic.hpp
@@ -8,6 +8,9 @@
 
 #include <boost/throw_exception.hpp>
 
+// forward declaration
+namespace boost { template<class T> class optional; }
+
 namespace boost { namespace program_options { 
 
     extern BOOST_PROGRAM_OPTIONS_DECL std::string arg;
@@ -150,6 +153,20 @@ namespace boost { namespace program_options {
                 boost::throw_exception(invalid_option_value(s[i]));
             }
         }
+    }
+
+    /** Validates optional arguments. */
+    template<class T, class charT>
+    void validate(boost::any& v,
+                  const std::vector<std::basic_string<charT> >& s,
+                  boost::optional<T>*,
+                  int)
+    {
+        validators::check_first_occurrence(v);
+        validators::get_single_string(s);
+        boost::any a;
+        validate(a, s, (T*)0, 0);
+        v = boost::any(boost::optional<T>(boost::any_cast<T>(a)));
     }
 
     template<class T, class charT>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1,3 +1,4 @@
+import testing ;
 
 project
     : requirements 
@@ -33,6 +34,7 @@ test-suite program_options :
     [ po-test unrecognized_test.cpp ]
     [ po-test required_test.cpp : required_test.cfg ]
     [ po-test exception_txt_test.cpp ]
+    [ po-test optional_test.cpp ]
     [ run options_description_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : options_description_no_rtti_test ]
     ;
         

--- a/test/optional_test.cpp
+++ b/test/optional_test.cpp
@@ -1,0 +1,53 @@
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/program_options.hpp>
+namespace po = boost::program_options;
+
+#include <boost/optional.hpp>
+
+#include <string>
+
+#include "minitest.hpp"
+
+std::vector<std::string> sv(const char* array[], unsigned size)
+{
+    std::vector<std::string> r;
+    for (unsigned i = 0; i < size; ++i)
+        r.push_back(array[i]);
+    return r;
+}
+
+void test_optional()
+{
+    boost::optional<int> foo, bar, baz;
+
+    po::options_description desc;
+    desc.add_options()
+        ("foo,f", po::value(&foo), "")
+        ("bar,b", po::value(&bar), "")
+        ("baz,z", po::value(&baz), "")
+        ;
+
+    const char* cmdline1_[] = { "--foo=12", "--bar", "1"};
+    std::vector<std::string> cmdline1 = sv(cmdline1_,
+                                           sizeof(cmdline1_)/sizeof(const char*));
+    po::variables_map vm;
+    po::store(po::command_line_parser(cmdline1).options(desc).run(), vm);
+    po::notify(vm);
+
+    BOOST_REQUIRE(!!foo);
+    BOOST_CHECK(*foo == 12);
+
+    BOOST_REQUIRE(!!bar);
+    BOOST_CHECK(*bar == 1);
+
+    BOOST_CHECK(!baz);
+}
+
+int main(int, char*[])
+{
+    test_optional();
+    return 0;
+}


### PR DESCRIPTION
For https://svn.boost.org/trac/boost/ticket/7495
