### PR TITLE
fix syntax with BOOST_NO_EXCEPTIONS

### DIFF
--- a/src/variables_map.cpp
+++ b/src/variables_map.cpp
@@ -42,7 +42,9 @@ namespace boost { namespace program_options {
         string option_name;
         string original_token;
 
+#ifndef BOOST_NO_EXCEPTIONS
         try
+#endif
         {
 
             // First, convert/store all given options


### PR DESCRIPTION
There's already an ifdef around the catch block, so I added one around "try" to match. 
