### PR TITLE
Support for semicolon comment delimiter

### DIFF
--- a/doc/overview.xml
+++ b/doc/overview.xml
@@ -500,6 +500,9 @@ notify(vm);
         <listitem><para>The <literal>#</literal> character introduces a
         comment that spans until the end of the line.</para>
         </listitem>
+        <listitem><para>The <literal>;</literal> character at the beginning of
+        a line makes the entire line a comment.</para>
+        </listitem>
       </itemizedlist>
 
       <para>The option names are relative to the section names, so

--- a/src/config_file.cpp
+++ b/src/config_file.cpp
@@ -90,6 +90,9 @@ namespace boost { namespace program_options { namespace detail {
             // strip '#' comments and whitespace
             if ((n = s.find('#')) != string::npos)
                 s = s.substr(0, n);
+            // if the first character is a ';' line is a comment
+            if (!s.empty() && ';' == s.at(0))
+                s = "";
             s = trim_ws(s);
 
             if (!s.empty()) {

--- a/test/parsers_test.cpp
+++ b/test/parsers_test.cpp
@@ -211,6 +211,7 @@ void test_config_file(const char* config_file)
 
     const char content1[] =
     " gv1 = 0#asd\n"
+    "; semi comment\n"
     "empty_value = \n"
     "plug3 = 7\n"
     "b = true\n"


### PR DESCRIPTION
INI style configuration files should support the semicolon ';' character, when
it is the first character on the line only, as a comment delimiter. Because
the '#' style comments are not allowed in strict MS INI files, this gives an
opening for files to be compatible in both and still have comments.