### PR TITLE
Namespace fix for diab (EDG) compiler

### DIFF
--- a/include/boost/program_options/eof_iterator.hpp
+++ b/include/boost/program_options/eof_iterator.hpp
@@ -68,7 +68,11 @@ namespace boost {
 
 
     private: // iterator core operations
-        friend class iterator_core_access;
+#ifdef __DCC__ 
+        friend class boost::iterator_core_access; 
+#else 
+        friend class iterator_core_access; 	 
+#endif
 
         void increment()
         {


### PR DESCRIPTION
Extracted from Boost.Config issue: https://svn.boost.org/trac/boost/ticket/11655.