### PR TITLE
Compile error with initializer list on c++03

### DIFF
--- a/test/exception_txt_test.cpp
+++ b/test/exception_txt_test.cpp
@@ -624,7 +624,7 @@ void test_empty_value_inner(options_description &opts, variables_map& vm) {
     positional_options_description popts;
     opts.add_options()("foo", value<uint32_t>()->value_name("<time>")->required());
     popts.add("foo", 1);
-    vector<string> tokens{""};
+    vector<string> tokens(1, "");
     parsed_options parsed = command_line_parser(tokens)
         .style(command_line_style::default_style & ~command_line_style::allow_guessing)
         .options(opts)


### PR DESCRIPTION
Some regression failures caused by list initialization, see [exception_txt_test / clang-gnu-linux-4.0~gnu++98](http://www.boost.org/development/tests/develop/developer/output/Flast-FreeBSD11-boost-bin-v2-libs-program_options-test-exception_txt_test-test-clang-gnu-linux-4-0~gnu++98-debug-link-static-threadapi-pthread.html).