### PR TITLE
add ci bits and readme

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+fixes:
+  - home/travis/build/*/boost-root/boost/::include/boost/
+  - home/travis/build/*/boost-root/libs/*/src/::src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,172 @@
+# Copyright 2016 Peter Dimov
+# Copyright 2017, 2018 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+#
+# Generic Travis CI build script for boostorg repositories
+#
+# Instructions for customizing this script for your library:
+# 
+# 1. Copy the ci/ directory from the same source into your project:
+#    ci/build.sh runs the build
+#    ci/codecov.sh is used to run a profiling build and upload results to codecov.io
+#    ci/coverity.sh is used to run a coverity build and upload results coverity scan
+# 2. Customize the compilers and language levels you want.  Default is C++03.
+# 3. Update the global B2 environment settings to your liking.
+# 4. If you have more than include/, src/, and test/ directories then
+#    add them to the depinst.py line as "--include tools" for tools/ (you
+#    can put multiple --include on the command line).
+# 5. If you want to enable Coverity Scan, you need to provide the environment
+#    variables COVERITY_SCAN_TOKEN and COVERITY_SCAN_NOTIFICATION_EMAIL in
+#    your github settings.
+# 6. Enable pull request builds in your boostorg/<library> account.
+# 7. Change the default C++ version in ci/*.sh (search for CXXSTD)
+#
+# That's it - the scripts will do everything else for you.
+
+sudo: false
+dist: trusty
+language: cpp
+
+env:
+  global:
+  # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+  # to use the default for a given environment, comment it out; recommend you build debug and release however..
+  # - B2_ADDRESS_MODEL=address-model=64,32
+  # - B2_LINK=link=shared,static
+  # - B2_THREADING=threading=multi,single
+    - B2_VARIANT=variant=release,debug
+
+install:
+  - export SELF=`basename $TRAVIS_BUILD_DIR`
+  - cd ..
+  - git clone -b $TRAVIS_BRANCH --depth 1 https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update -q --init tools/boostdep
+  - git submodule update -q --init tools/build
+  - git submodule update -q --init tools/inspect
+  - cp -r $TRAVIS_BUILD_DIR/* libs/$SELF
+  - export BOOST_ROOT="`pwd`"
+  - export PATH="`pwd`":$PATH 
+  - python tools/boostdep/depinst/depinst.py $SELF --include example
+  - ./bootstrap.sh
+  - ./b2 headers
+
+addons:
+  apt:
+    packages:
+      - binutils-gold
+      - gdb
+      - libc6-dbg
+        
+branches:
+  only:
+    - develop
+    - master
+    
+script:
+  - cd libs/$SELF
+  - ci/build.sh
+
+jobs:
+  include:
+    - os: linux
+      env: 
+        - COMMENT="C++03"
+        - TOOLSET=gcc,gcc-7
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - COMMENT="C++11"
+        - TOOLSET=clang
+        - CXXSTD=11
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+    - os: linux
+      env: 
+        - COMMENT=valgrind
+        - TOOLSET=clang 
+        - B2_VARIANT=variant=debug
+        - TESTFLAGS=testing.launcher=valgrind
+      addons:
+        apt:
+          packages:
+            - clang-5.0
+            - libstdc++-7-dev
+            - valgrind
+          sources:
+            - llvm-toolchain-trusty-5.0
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env:
+        - COMMENT=cppcheck
+      script:
+        - libs/$SELF/ci/cppcheck.sh
+
+    - os: linux
+      env:
+        - COMMENT=UBSAN
+        - B2_VARIANT=variant=debug
+        - TOOLSET=gcc-7
+        - CXXFLAGS="cxxflags=-fno-omit-frame-pointer cxxflags=-fsanitize=undefined cxxflags=-fno-sanitize-recover=undefined"
+        - LINKFLAGS="linkflags=-fsanitize=undefined linkflags=-fno-sanitize-recover=undefined"
+        - UBSAN_OPTIONS=print_stacktrace=1
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+    - os: linux
+      env: 
+        - COMMENT=CodeCov
+        - TOOLSET=gcc-7
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+      script:
+        - pushd /tmp && git clone https://github.com/linux-test-project/lcov.git && cd lcov && sudo make install && which lcov && lcov --version && popd
+        - cd libs/$SELF
+        - ci/codecov.sh
+
+    #################### Jobs to run on every pull request ####################
+  # osx was disabled because it is very slow to start (can delay builds by 30 minutes)
+  # - os: osx
+  #   osx_image: xcode9
+  #   env:
+  #     - TOOLSET=clang
+  #     - CXXSTD=03,11
+
+    #################### Jobs to run on pushes to master, develop ###################
+ 
+    # Coverity Scan
+    - os: linux
+      if: (branch IN (develop, master)) AND (type IN (cron, push))
+      env:
+        - COMMENT="Coverity Scan"
+        - TOOLSET=gcc
+      script:
+        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+        - cd libs/$SELF
+        - ci/coverity.sh
+
+notifications:
+  email:
+    false
+

--- a/Jamfile
+++ b/Jamfile
@@ -1,0 +1,11 @@
+#  Boost.ProgramOptions Library Jamfile
+#
+#  Copyright (c) 2018 James E. King III
+#
+#  Use, modification, and distribution are subject to the
+#  Boost Software License, Version 1.0. (See accompanying file
+#  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# please order by name to ease maintenance
+build-project example ;
+build-project test ;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+Program Options, part of the collection of [Boost C++ Libraries](http://github.com/boostorg), allows for definition and acquisition of (name, value) pairs from the user via conventional methods such as command line and config file.  It is roughly analogous to getopt_long, but for use with C++.
+
+### License
+
+Distributed under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).
+
+### Properties
+
+* C++03
+* Requires Linking
+
+### Build Status
+(in progress...)
+<!--
+Branch          | Travis | Appveyor | Coverity Scan | codecov.io | Deps | Docs | Tests |
+:-------------: | ------ | -------- | ------------- | ---------- | ---- | ---- | ----- |
+[`master`](https://github.com/boostorg/date_time/tree/master) | [![Build Status](https://travis-ci.org/boostorg/date_time.svg?branch=master)](https://travis-ci.org/boostorg/date_time) | [![Build status](https://ci.appveyor.com/api/projects/status/upf5c528fy09fudk?svg=true)](https://ci.appveyor.com/project/jeking3/date-time-1evbf) | [![Coverity Scan Build Status](https://scan.coverity.com/projects/14908/badge.svg)](https://scan.coverity.com/projects/boostorg-date_time) | [![codecov](https://codecov.io/gh/boostorg/date_time/branch/master/graph/badge.svg)](https://codecov.io/gh/boostorg/date_time/branch/master) | [![Deps](https://img.shields.io/badge/deps-master-brightgreen.svg)](https://pdimov.github.io/boostdep-report/master/date_time.html) | [![Documentation](https://img.shields.io/badge/docs-master-brightgreen.svg)](http://www.boost.org/doc/libs/master/doc/html/date_time.html) | [![Enter the Matrix](https://img.shields.io/badge/matrix-master-brightgreen.svg)](http://www.boost.org/development/tests/master/developer/date_time.html) 
+[`develop`](https://github.com/boostorg/date_time/tree/develop) | [![Build Status](https://travis-ci.org/boostorg/date_time.svg?branch=develop)](https://travis-ci.org/boostorg/date_time) | [![Build status](https://ci.appveyor.com/api/projects/status/upf5c528fy09fudk/branch/develop?svg=true)](https://ci.appveyor.com/project/boostorg/date_time/branch/develop) | [![Coverity Scan Build Status](https://scan.coverity.com/projects/14908/badge.svg)](https://scan.coverity.com/projects/boostorg-date_time) | [![codecov](https://codecov.io/gh/boostorg/date_time/branch/develop/graph/badge.svg)](https://codecov.io/gh/boostorg/date_time/branch/develop) | [![Deps](https://img.shields.io/badge/deps-develop-brightgreen.svg)](https://pdimov.github.io/boostdep-report/develop/date_time.html) | [![Documentation](https://img.shields.io/badge/docs-develop-brightgreen.svg)](http://www.boost.org/doc/libs/develop/doc/html/date_time.html) | [![Enter the Matrix](https://img.shields.io/badge/matrix-develop-brightgreen.svg)](http://www.boost.org/development/tests/develop/developer/date_time.html)
+ -->
+ 
+### Directories
+
+| Name      | Purpose                        |
+| --------- | ------------------------------ |
+| `build`   | build script for link library  |
+| `ci`      | continuous integration scripts |
+| `doc`     | documentation                  |
+| `example` | use case examples              |
+| `include` | headers                        |
+| `src`     | source code for link library   |
+| `test`    | unit tests                     |
+
+### More information
+
+* [Ask questions](http://stackoverflow.com/questions/ask?tags=c%2B%2B,boost,boost-program_options): Be sure to read the documentation first to see if it answers your question.
+* [Report bugs](https://github.com/boostorg/program_options/issues): Be sure to mention Boost version, platform and compiler you're using. A small compilable code sample to reproduce the problem is always good as well.
+* [Submit Pull Requests](https://github.com/boostorg/program_options/pulls) against the **develop** branch. Note that by submitting patches you agree to license your modifications under the [Boost Software License, Version 1.0](http://www.boost.org/LICENSE_1_0.txt).  Be sure to include tests proving your changes work properly.
+* Discussions about the library are held on the [Boost developers mailing list](http://www.boost.org/community/groups.html#main). Be sure to read the [discussion policy](http://www.boost.org/community/policy.html) before posting and add the `[date_time]` tag at the beginning of the subject line.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,78 @@
+# Copyright 2016, 2017 Peter Dimov
+# Copyright (C) 2017, 2018 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+
+# When copying this to a new library, be sure to update the name of the library
+# in two places (once each at the top of install: and test_script:)
+
+version: 1.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - develop
+    - master
+
+matrix:
+  allow_failures:
+    - MAYFAIL: true
+
+environment:
+  global:
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+    # see: http://www.boost.org/build/doc/html/bbv2/overview/invocation.html#bbv2.overview.invocation.properties
+    # to use the default for a given environment, comment it out; recommend you build debug and release however..
+    # on Windows it is important to exercise all the possibilities, especially shared vs static
+    # B2_ADDRESS_MODEL: address-model=64,32
+    # B2_LINK: link=shared,static
+    # B2_THREADING: threading=multi,single
+    B2_VARIANT: variant=release,debug
+    CXXSTD: 03
+
+  matrix:
+    - FLAVOR: Visual Studio 2017
+      TOOLSET: msvc-14.1
+      B2_ADDRESS_MODEL: address-model=64,32
+    - FLAVOR: Visual Studio 2013
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+      TOOLSET: msvc-12.0
+    - FLAVOR:  mingw32
+      ARCH:    i686
+      B2_ADDRESS_MODEL: address-model=32
+      SCRIPT:  ci\mingw.bat
+    - FLAVOR:  mingw64
+      ARCH:    x86_64
+      B2_ADDRESS_MODEL: address-model=64
+      SCRIPT:  ci\mingw.bat
+    - FLAVOR: cygwin (64-bit)
+      ADDPATH: C:\cygwin64\bin;
+      B2_ADDRESS_MODEL: address-model=64
+      TOOLSET: gcc
+      MAYFAIL: true
+    - FLAVOR: cygwin (32-bit)
+      ADDPATH: C:\cygwin\bin;
+      B2_ADDRESS_MODEL: address-model=32
+      TOOLSET: gcc
+      MAYFAIL: true
+
+install:
+  - set SELF=program_options
+  - cd ..
+  - git clone -b %APPVEYOR_REPO_BRANCH% --depth 1 https://github.com/boostorg/boost.git boost-root
+  - cd boost-root
+  - git submodule update -q --init tools/boostdep
+  - git submodule update -q --init tools/build
+  - git submodule update -q --init tools/inspect
+  - xcopy /s /e /q %APPVEYOR_BUILD_FOLDER% libs\%SELF%
+  - python tools/boostdep/depinst/depinst.py --include example %SELF%
+  - cmd /c bootstrap
+  - b2 headers
+
+build: off
+
+test_script:
+  - set SELF=program_options
+  - PATH=%ADDPATH%%PATH%
+  - IF DEFINED SCRIPT (call libs\%SELF%\%SCRIPT%) ELSE (b2 libs/%SELF% toolset=%TOOLSET% cxxstd=%CXXSTD% %CXXFLAGS% %DEFINES% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3)

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+#
+# Copyright 2017 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run in travis to perform a bjam build
+# cwd should be $BOOST_ROOT/libs/$SELF before running
+#
+
+set -ex
+
+# default language level: c++03
+if [[ -z "$CXXSTD" ]]; then
+    CXXSTD=03
+fi
+
+$BOOST_ROOT/b2 . toolset=$TOOLSET cxxstd=$CXXSTD $CXXFLAGS $DEFINES $LINKFLAGS $TESTFLAGS $B2_ADDRESS_MODEL $B2_LINK $B2_THREADING $B2_VARIANT -j3 $*

--- a/ci/codecov.sh
+++ b/ci/codecov.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+#
+# Copyright 2017, 2018 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run in travis to perform codecov.io integration
+#
+
+###
+### NOTE: Make sure you grab .codecov.yml
+###
+
+# assumes cwd is the top level directory of the boost project
+# assumes an environment variable $SELF is the boost project name
+
+set -ex
+
+B2_VARIANT=debug
+ci/build.sh cxxflags=-fprofile-arcs cxxflags=-ftest-coverage linkflags=-fprofile-arcs linkflags=-ftest-coverage
+
+# switch back to the original source code directory
+cd $TRAVIS_BUILD_DIR
+
+# get the version of lcov
+lcov --version
+
+# coverage files are in ../../b2 from this location
+lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --base-directory "$BOOST_ROOT/libs/$SELF" --directory "$BOOST_ROOT" --capture --output-file all.info
+
+# all.info contains all the coverage info for all projects - limit to ours
+lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --extract all.info "*/boost/$SELF/*" "*/libs/$SELF/src/*" --output-file coverage.info
+
+# dump a summary on the console - helps us identify problems in pathing
+lcov --gcov-tool=gcov-7 --rc lcov_branch_coverage=1 --list coverage.info
+
+#
+# upload to codecov.io
+#
+curl -s https://codecov.io/bash > .codecov
+chmod +x .codecov
+./.codecov -f coverage.info -X gcov -x "gcov-7"

--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -1,0 +1,42 @@
+#! /bin/bash
+#
+# Copyright 2017 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run in travis to perform a Coverity Scan build
+# To skip the coverity integration download (which is huge) if
+# you already have it from a previous run, add --skipdownload
+#
+
+#
+# Environment Variables
+#
+# COVERITY_SCAN_NOTIFICATION_EMAIL  - email address to notify
+# COVERITY_SCAN_TOKEN               - the Coverity Scan token (should be secure)
+# SELF                              - the boost libs directory name
+
+set -ex
+
+pushd /tmp
+if [[ "$1" != "--skipdownload" ]]; then
+  rm -rf coverity_tool.tgz cov-analysis*
+  wget https://scan.coverity.com/download/linux64 --post-data "token=$COVERITY_SCAN_TOKEN&project=boostorg/$SELF" -O coverity_tool.tgz
+  tar xzf coverity_tool.tgz
+fi
+COVBIN=$(echo $(pwd)/cov-analysis*/bin)
+export PATH=$COVBIN:$PATH
+popd
+
+ci/build.sh clean
+rm -rf cov-int/
+cov-build --dir cov-int ci/build.sh
+tar cJf cov-int.tar.xz cov-int/
+curl --form token="$COVERITY_SCAN_TOKEN" \
+     --form email="$COVERITY_SCAN_NOTIFICATION_EMAIL" \
+     --form file=@cov-int.tar.xz \
+     --form version="$(git describe --tags)" \
+     --form description="boostorg/$SELF" \
+     https://scan.coverity.com/builds?project="boostorg/$SELF"
+

--- a/ci/cppcheck.sh
+++ b/ci/cppcheck.sh
@@ -1,0 +1,38 @@
+#! /bin/bash
+#
+# Copyright 2018 James E. King III
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+#      http://www.boost.org/LICENSE_1_0.txt)
+#
+# Bash script to run in travis to perform a cppcheck
+# cwd should be $BOOST_ROOT before running
+#
+
+set -ex
+
+# default language level: c++03
+if [[ -z "$CXXSTD" ]]; then
+    CXXSTD=03
+fi
+
+# Travis' ubuntu-trusty comes with cppcheck 1.62 which is pretty old
+# default cppcheck version: 1.82
+if [[ -z "$CPPCHKVER" ]]; then
+    CPPCHKVER=1.82
+fi
+
+pushd ~
+wget https://github.com/danmar/cppcheck/archive/$CPPCHKVER.tar.gz
+tar xzf $CPPCHKVER.tar.gz
+mkdir cppcheck-build
+cd cppcheck-build
+cmake ../cppcheck-$CPPCHKVER -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX=~/cppcheck
+make -j3 install
+popd
+
+~/cppcheck/bin/cppcheck -I. --std=c++$CXXSTD --enable=all --error-exitcode=1 \
+         --force --check-config --suppress=*:boost/preprocessor/tuple/size.hpp \
+         -UBOOST_USER_CONFIG -UBOOST_COMPILER_CONFIG -UBOOST_STDLIB_CONFIG -UBOOST_PLATFORM_CONFIG \
+         libs/$SELF 2>&1 | grep -v 'Cppcheck does not need standard library headers'
+

--- a/ci/mingw.bat
+++ b/ci/mingw.bat
@@ -1,0 +1,50 @@
+::
+:: MinGW Build Script for Appveyor, leveraging the MSYS2 installation
+:: Copyright (C) 2018 James E. King III
+:: Distributed under the Boost Software License, Version 1.0.
+:: (See accompanying file LICENSE_1_0.txt or copy at http://boost.org/LICENSE_1_0.txt)
+::
+
+@ECHO ON
+SETLOCAL EnableDelayedExpansion
+
+:: Set up the toolset
+echo using gcc : %FLAVOR% : %ARCH%-w64-mingw32-g++.exe ; > %USERPROFILE%\user-config.jam
+SET UPPERFLAVOR=%FLAVOR%
+CALL :TOUPPER UPPERFLAVOR
+
+:: Install packages needed to build boost
+:: Optional: comment out ones this library does not need, 
+:: so people can copy this script to another library.
+
+FOR %%a IN ("gcc" "icu" "libiconv" "openssl" "xz" "zlib") DO (
+    c:\msys64\usr\bin\env MSYSTEM=%UPPERFLAVOR% c:\msys64\usr\bin\bash -l -c ^
+      "pacman --sync --needed --noconfirm %FLAVOR%/mingw-w64-%ARCH%-%%a" || EXIT /B
+)
+c:\msys64\usr\bin\env MSYSTEM=%UPPERFLAVOR% c:\msys64\usr\bin\bash -l -c ^
+  "pacman --sync --needed --noconfirm python3" || EXIT /B
+
+::
+:: Now build things...
+::
+
+c:\msys64\usr\bin\env MSYSTEM=%UPPERFLAVOR% c:\msys64\usr\bin\bash -l -c ^
+  "cd %CD:\=/% && ./bootstrap.sh --with-toolset=gcc" || EXIT /B
+
+c:\msys64\usr\bin\env MSYSTEM=%UPPERFLAVOR% c:\msys64\usr\bin\bash -l -c ^
+  "cd %CD:\=/% && ./b2 libs/%SELF% toolset=gcc-%FLAVOR% cxxstd=%CXXSTD% %CXXFLAGS% %DEFINES% %B2_ADDRESS_MODEL% %B2_LINK% %B2_THREADING% %B2_VARIANT% -j3" || EXIT /B
+
+EXIT /B 0
+
+::
+:: Function to uppercase a variable
+:: from: https://stackoverflow.com/questions/34713621/batch-converting-variable-to-uppercase
+::
+
+:TOUPPER <variable>
+@ECHO OFF
+FOR %%a IN ("a=A" "b=B" "c=C" "d=D" "e=E" "f=F" "g=G" "h=H" "i=I"
+            "j=J" "k=K" "l=L" "m=M" "n=N" "o=O" "p=P" "q=Q" "r=R"
+            "s=S" "t=T" "u=U" "v=V" "w=W" "x=X" "y=Y" "z=Z"      ) DO ( CALL SET %~1=%%%~1:%%~a%% )
+@ECHO ON
+GOTO :EOF


### PR DESCRIPTION
### Summary ###

This pull request adds support for:

* Travis CI
  * Various gcc and clang builds
  * cppcheck
  * ubsan
  * covecov.io build
* Appveyor
  * Visual Studio 2017 and 2013 builds
  * mingw 32-bit and 64-bit builds
  * cygwin 32-bit and 64-bit builds
* codecov.io integration, which will post code coverage deltas into each pull request that runs successfully (really cool!)
* Coverity Scan support (when enabled), also see #46 which came out of this work.

### Example Build Jobs ###

Appveyor: https://ci.appveyor.com/project/jeking3/program-options/build/1.0.16-develop
(note the red builds are already tracked in #45 so I made these build failures non-fatal)

Travis: https://travis-ci.org/jeking3/program_options/builds/350461368
(note the fialed UBSAN issue is tracked in #44 but this is serious so I left it as fatal!)

### Work Required by the Repository Owner ###

After merging this pull request the repository owner must perform a number of tasks:

* Add the boostorg/program_options project to your Travis CI account.  Make sure it is the boostorg one.  Sometimes you have to click on "sync with github" to get it to show up.  If it does not show up you will need to request Admin level access through the Boost Admin list.
* Add the boostorg/program_options project to your Appveyor account.
* Update the README.md at the top, uncommenting the status section and fixing all the links to use your project.
* I will create a Coverity Scan project after this pull request is merged and add the repository owner as an owner/admin; the repository owner will then need to modify the boostorg/program_options travis project with two environment variables that enable coverity scan builds to work.

This fixes #43 