### PR TITLE
Fix regression (vs 1.66.0 and older) to allow argc == 0 for command_line parser

### DIFF
--- a/include/boost/program_options/detail/parsers.hpp
+++ b/include/boost/program_options/detail/parsers.hpp
@@ -24,7 +24,11 @@ namespace boost { namespace program_options {
     basic_command_line_parser<charT>::
     basic_command_line_parser(int argc, const charT* const argv[])
     : detail::cmdline(
-        to_internal(std::vector<std::basic_string<charT> >(argv+1, argv+argc))),
+        to_internal(std::vector<std::basic_string<charT> >(
+                      // When argc == 0, we must produce a valid empty range,
+                      // even with a nullptr argv.  We can ignore the
+                      // obviously illegal argc < 0.
+                      argc ? argv+1 : argv, argv+argc))),
         m_desc()
     {}
 

--- a/test/parsers_test.cpp
+++ b/test/parsers_test.cpp
@@ -155,6 +155,24 @@ void test_not_crashing_with_empty_string_values() {
                     const_cast<char**>(cmdline4), desc2), vm);
 }
 
+void test_not_crashing_with_empty_range() {
+    // Check that we don't crash when an empty range is provided.
+    options_description desc;
+    desc.add_options()("arg", po::value<string>());
+    {
+        const char* cmdline[] = {};
+        variables_map vm;
+        po::store(
+                po::parse_command_line(sizeof(cmdline) / sizeof(const char*),
+                        cmdline, desc), vm);
+    }
+    {
+        variables_map vm;
+        const char* const* cmdline = NULL;
+        po::store(po::parse_command_line(0, cmdline, desc), vm);
+    }
+}
+
 void test_multitoken() {
     const char* cmdline5[] = { "", "-p7", "-o", "1", "2", "3", "-x8" };
     options_description desc3;
@@ -246,6 +264,7 @@ void test_command_line()
     command_line::test_many_different_options();
     // Check that we don't crash on empty values of type 'string'
     command_line::test_not_crashing_with_empty_string_values();
+    command_line::test_not_crashing_with_empty_range();
     command_line::test_multitoken();
     command_line::test_multitoken_vector_option();
     command_line::test_multitoken_and_multiname();

--- a/test/parsers_test.cpp
+++ b/test/parsers_test.cpp
@@ -160,11 +160,9 @@ void test_not_crashing_with_empty_range() {
     options_description desc;
     desc.add_options()("arg", po::value<string>());
     {
-        const char* cmdline[] = {};
+        const char* cmdline[] = { "ignored" };
         variables_map vm;
-        po::store(
-                po::parse_command_line(sizeof(cmdline) / sizeof(const char*),
-                        cmdline, desc), vm);
+        po::store(po::parse_command_line(0, cmdline, desc), vm);
     }
     {
         variables_map vm;


### PR DESCRIPTION
When upgrading from Boost 1.66.0 to 1.67.0, a test failed because `boost::program_options::command_line_parser` crashed when passed an `argc` value equal to 0.  While this isn't a value that a program is likely to get from `main()`, it seems reasonable that it should work to define an empty set of input arguments, especially since that has been the traditional (if undocumented) behaviour of this class.

The commit that caused this change in behaviour seems to be https://github.com/boostorg/program_options/commit/110772c0ac672ef2972d251886215bb89933bf00.

This PR fixes this regression and adds a test for such cases.

