### PR TITLE
Fix long case insensitive and short case sensitive combo.

### DIFF
--- a/src/options_description.cpp
+++ b/src/options_description.cpp
@@ -113,6 +113,7 @@ namespace boost { namespace program_options {
 
         if (result != full_match)
         {
+            std::string local_option(short_ignore_case ? tolower_(option) : option);
             std::string local_short_name(short_ignore_case ? tolower_(m_short_name) : m_short_name);
 
             if (local_short_name == local_option)


### PR DESCRIPTION
The local_option update for the short_name match was removed in v1.68.0, but it is needed to allow for case insensitive long names combined with case sensitive short names.  See #74 for more info about the problem.