### PR TITLE
Don't require non-const reference to call notify()

### DIFF
--- a/include/boost/program_options/variables_map.hpp
+++ b/include/boost/program_options/variables_map.hpp
@@ -50,7 +50,7 @@ namespace boost { namespace program_options {
 
 
     /** Runs all 'notify' function for options in 'm'. */
-    BOOST_PROGRAM_OPTIONS_DECL void notify(variables_map& m);
+    BOOST_PROGRAM_OPTIONS_DECL void notify(const variables_map& m);
 
     /** Class holding value of option. Contains details about how the
         value is set and allows to conveniently obtain the value.
@@ -157,7 +157,7 @@ namespace boost { namespace program_options {
         // Override to clear some extra fields.
         void clear();
 
-        void notify();
+        void notify() const;
 
     private:
         /** Implementation of abstract_variables_map::get

--- a/src/variables_map.cpp
+++ b/src/variables_map.cpp
@@ -148,7 +148,7 @@ namespace boost { namespace program_options {
     }
 
     BOOST_PROGRAM_OPTIONS_DECL
-    void notify(variables_map& vm)
+    void notify(const variables_map& vm)
     {
         vm.notify();
     }
@@ -210,7 +210,7 @@ namespace boost { namespace program_options {
     }
 
     void
-    variables_map::notify()
+    variables_map::notify() const
     {
         // This checks if all required options occur
         for (map<string, string>::const_iterator r = m_required.begin();
@@ -223,12 +223,11 @@ namespace boost { namespace program_options {
             if (iter == end() || iter->second.empty())
             {
                 boost::throw_exception(required_option(display_opt));
-
             }
         }
 
         // Lastly, run notify actions.
-        for (map<string, variable_value>::iterator k = begin();
+        for (map<string, variable_value>::const_iterator k = begin();
              k != end();
              ++k)
         {


### PR DESCRIPTION
This fixes notify() and variables_map::notify() to not require a non-const reference to the variables_map. This is useful if you are passing this object from one module to another and want to trigger handling of those variables in the new module's context without enabling that new module to mutate the shared map's state.