### PR TITLE
Change test/Jamfile to work after `bcp --namespace`

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -2,20 +2,20 @@ import testing ;
 
 project
     : requirements 
-    <library>../build//boost_program_options
+    <library>/boost//program_options
     <link>static
     <variant>debug
     
 #    <define>_GLIBCXX_CONCEPT_CHECKS
 #    <define>_GLIBCXX_DEBUG
     ;
-    
+
 rule po-test ( source : input-file ? )
 {
     return
         [ run $(source) : : $(input-file) ]
         [ run $(source) : : $(input-file) 
-          : <link>shared <define>BOOST_PROGRAM_OPTIONS_DYN_LINK=1
+          : <link>shared
           : $(source:B)_dll ] 
     ;   
 }    
@@ -37,7 +37,7 @@ test-suite program_options :
     [ po-test optional_test.cpp ]
     [ run options_description_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : options_description_no_rtti_test ]
     ;
-        
+
 exe test_convert : test_convert.cpp ;   
 
 # `quick` target (for CI)


### PR DESCRIPTION
I'm trying to fix `bcp` to work again and adding tests for it (https://github.com/boostorg/bcp/commit/1025e7e04ba1056e4f47f3ca3eb7d3b52c8d612c), and I'm using `program_options` because it's the only library exercising the `boost-lib` rule from `Jamroot`, which was one of the things that were broken.

`bcp --namespace=foo` renames the libraries from `boost_bar` to `foo_bar`, but it doesn't touch `test/Jamfile`, which still wanted to link to `boost_program_options`. Changing it to refer to `/boost//program_options` instead fixes it.

The manual `<define>BOOST_PROGRAM_OPTIONS_DYN_LINK=1` was unnecessary, because it was supplied by `boost-lib`, and it masked the fact that `boost-lib` was erroneously changed by `bcp` to define `FOO_PROGRAM_OPTIONS_DYN_LINK` instead.