### PR TITLE
Remove manual RTTI defines

### DIFF
--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -35,7 +35,7 @@ test-suite program_options :
     [ po-test required_test.cpp : required_test.cfg ]
     [ po-test exception_txt_test.cpp ]
     [ po-test optional_test.cpp ]
-    [ run options_description_test.cpp : : : <rtti>off <define>BOOST_NO_RTTI <define>BOOST_NO_TYPEID : options_description_no_rtti_test ]
+    [ run options_description_test.cpp : : : <rtti>off : options_description_no_rtti_test ]
     ;
         
 exe test_convert : test_convert.cpp ;   


### PR DESCRIPTION
These defines are set automatically by Boost.Config as appropriate.