### PR TITLE
Introduce variable_value::as_optional<>()

### DIFF
--- a/include/boost/program_options/variables_map.hpp
+++ b/include/boost/program_options/variables_map.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/any.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/optional.hpp>
 
 #include <string>
 #include <map>
@@ -72,6 +73,16 @@ namespace boost { namespace program_options {
        template<class T>
        T& as() {
            return boost::any_cast<T&>(v);
+       }
+
+       /** If stored value is of type T, returns optional<T> having that value.
+           If variable is empty, returns optional<T> having the none.
+           Otherwise, throws boost::bad_any_cast exception. */
+       template<class T>
+       optional<T> as_optional() const {
+           if (empty()) return none;
+
+           return as<T>();
        }
 
         /// Returns true if no value is stored.

--- a/test/variable_map_test.cpp
+++ b/test/variable_map_test.cpp
@@ -51,6 +51,8 @@ void test_variable_map()
     BOOST_CHECK(vm.count("biz") == 1);
     BOOST_CHECK(vm["biz"].as<string>() == "3");
     BOOST_CHECK(vm["output"].as<string>() == "foo");
+    BOOST_CHECK(vm["bar"].as_optional<string>() == optional<string>("11"));
+    BOOST_CHECK(vm["buz"].as_optional<string>() == none);
 
     int i;
     desc.add_options()
@@ -71,6 +73,8 @@ void test_variable_map()
     BOOST_CHECK(vm2["zak"].as<int>() == 13);
     BOOST_CHECK(vm2["opt"].as<bool>() == false);
     BOOST_CHECK(i == 13);
+    BOOST_CHECK(vm2["zak"].as_optional<int>() == optional<int>(13));
+    BOOST_CHECK(vm2["zoo"].as_optional<int>() == none);
 
     options_description desc2;
     desc2.add_options()


### PR DESCRIPTION
In some cases, optional<> types are used to specify missed input parameters in
functions. It may be the case when missed parameter has meaning 'unknown'
rather than 'default' and requires different behaviour.

Introduce convenient interface for program_options to write code as the
following:

    const auto opt = va['opt'].as_optional<T>();

as_optional<T>() returns the value when stored type is T,
empty optional<T> when variable_value is empty,
or raise bad_cast exception when stored type is other than T (as in case of
as<T>()).

The latter case is considered as a kind of logic/runtime error since the user
is supposed to know which type he expects that the variable has.