### PR TITLE
Avoid deprecated bind placeholders in global namespace

### DIFF
--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -15,7 +15,7 @@
 #include <boost/program_options/positional_options.hpp>
 #include <boost/throw_exception.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <string>
 #include <utility>
@@ -28,6 +28,8 @@
 #include <cstdio>
 
 #include <iostream>
+
+using namespace boost::placeholders;
 
 namespace boost { namespace program_options {
 

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -19,9 +19,10 @@
 #include <boost/program_options/detail/utf8_codecvt_facet.hpp>
 #include <boost/throw_exception.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 using namespace std;
+using namespace boost::placeholders;
 
 namespace boost { namespace detail {
 

--- a/src/parsers.cpp
+++ b/src/parsers.cpp
@@ -16,7 +16,7 @@
 #include <boost/program_options/environment_iterator.hpp>
 #include <boost/program_options/detail/convert.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/throw_exception.hpp>
 
 #include <cctype>
@@ -61,6 +61,7 @@ extern char** environ;
 #endif
 
 using namespace std;
+using namespace boost::placeholders;
 
 namespace boost { namespace program_options {
 


### PR DESCRIPTION
This fixes numerous yet annoying compilation warnings:

```
  note: #pragma message:
    The practice of declaring the Bind placeholders (_1, _2, ...)
    in the global namespace is deprecated.
    Please use <boost/bind/bind.hpp> + using namespace boost::placeholders,
    or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.
```

This is somewhat related to PR #91 

-----

Apart from obscuring the output of compilation of libraries using Boost.Test, it may be troublesome on CI builds. On many CI services every line of log counts and if log dumps become too long, 
builds are terminated.