### PR TITLE
Use BOOST_OVERRIDE

### DIFF
--- a/include/boost/program_options/detail/config_file.hpp
+++ b/include/boost/program_options/detail/config_file.hpp
@@ -8,8 +8,8 @@
 #define BOOST_CONFIG_FILE_VP_2003_01_02
 
 #include <iosfwd>
-#include <string>
 #include <set>
+#include <string>
 
 #include <boost/noncopyable.hpp>
 #include <boost/program_options/config.hpp>
@@ -131,7 +131,7 @@ namespace boost { namespace program_options { namespace detail {
 
     private: // base overrides
 
-        bool getline(std::string&);
+        bool getline(std::string&) BOOST_OVERRIDE;
 
     private: // internal data
         shared_ptr<std::basic_istream<charT> > is;

--- a/include/boost/program_options/errors.hpp
+++ b/include/boost/program_options/errors.hpp
@@ -9,10 +9,10 @@
 
 #include <boost/program_options/config.hpp>
 
-#include <string>
-#include <stdexcept>
-#include <vector>
 #include <map>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 
 #if defined(BOOST_MSVC)
@@ -121,7 +121,7 @@ namespace boost { namespace program_options {
         /** gcc says that throw specification on dtor is loosened 
          *  without this line                                     
          *  */ 
-        ~error_with_option_name() throw() {}
+        ~error_with_option_name() throw() BOOST_OVERRIDE {}
 
 
         //void dump() const
@@ -183,7 +183,7 @@ namespace boost { namespace program_options {
 
         /** Creates the error_message on the fly
          *      Currently a thin wrapper for substitute_placeholders() */
-        virtual const char* what() const throw();
+        const char* what() const throw() BOOST_OVERRIDE;
 
     protected:
         /** Used to hold the error text returned by what() */
@@ -209,7 +209,7 @@ namespace boost { namespace program_options {
         multiple_values() 
          : error_with_option_name("option '%canonical_option%' only takes a single argument"){}
 
-        ~multiple_values() throw() {}
+        ~multiple_values() throw() BOOST_OVERRIDE {}
     };
 
     /** Class thrown when there are several occurrences of an
@@ -220,8 +220,7 @@ namespace boost { namespace program_options {
         multiple_occurrences() 
          : error_with_option_name("option '%canonical_option%' cannot be specified more than once"){}
 
-        ~multiple_occurrences() throw() {}
-
+        ~multiple_occurrences() throw() BOOST_OVERRIDE {}
     };
 
     /** Class thrown when a required/mandatory option is missing */
@@ -233,7 +232,7 @@ namespace boost { namespace program_options {
        {
        }
 
-       ~required_option() throw() {}
+       ~required_option() throw() BOOST_OVERRIDE {}
     };
 
     /** Base class of unparsable options,
@@ -243,7 +242,7 @@ namespace boost { namespace program_options {
      *  It makes no sense to have an option name, when we can't match an option to the
      *      parameter
      *  
-     *  Having this a part of the error_with_option_name hierachy makes error handling
+     *  Having this a part of the error_with_option_name hierarchy makes error handling
      *      a lot easier, even if the name indicates some sort of conceptual dissonance!
      *  
      *   */
@@ -256,9 +255,9 @@ namespace boost { namespace program_options {
         }
 
         /** Does NOT set option name, because no option name makes sense */
-        virtual void set_option_name(const std::string&) {}
+        void set_option_name(const std::string&) BOOST_OVERRIDE {}
 
-        ~error_with_no_option_name() throw() {}
+        ~error_with_no_option_name() throw() BOOST_OVERRIDE {}
     };
 
 
@@ -270,12 +269,12 @@ namespace boost { namespace program_options {
         {
         }
 
-        ~unknown_option() throw() {}
+        ~unknown_option() throw() BOOST_OVERRIDE {}
     };
 
 
 
-    /** Class thrown when there's ambiguity amoung several possible options. */
+    /** Class thrown when there's ambiguity among several possible options. */
     class BOOST_PROGRAM_OPTIONS_DECL ambiguous_option : public error_with_no_option_name {
     public:
         ambiguous_option(const std::vector<std::string>& xalternatives)
@@ -283,13 +282,13 @@ namespace boost { namespace program_options {
             m_alternatives(xalternatives)
         {}
 
-        ~ambiguous_option() throw() {}
+        ~ambiguous_option() throw() BOOST_OVERRIDE {}
 
         const std::vector<std::string>& alternatives() const throw() {return m_alternatives;}
 
     protected:
         /** Makes all substitutions using the template */
-        virtual void substitute_placeholders(const std::string& error_template) const;
+        void substitute_placeholders(const std::string& error_template) const BOOST_OVERRIDE;
     private:
         // TODO: copy ctor might throw
         std::vector<std::string> m_alternatives;
@@ -320,7 +319,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        ~invalid_syntax() throw() {}
+        ~invalid_syntax() throw() BOOST_OVERRIDE {}
 
         kind_t kind() const {return m_kind;}
 
@@ -340,10 +339,10 @@ namespace boost { namespace program_options {
             m_substitutions["invalid_line"] = invalid_line;
         }
 
-        ~invalid_config_file_syntax() throw() {}
+        ~invalid_config_file_syntax() throw() BOOST_OVERRIDE {}
 
         /** Convenience functions for backwards compatibility */
-        virtual std::string tokens() const {return m_substitutions.find("invalid_line")->second;    }
+        std::string tokens() const BOOST_OVERRIDE { return m_substitutions.find("invalid_line")->second; }
     };
 
 
@@ -355,7 +354,8 @@ namespace boost { namespace program_options {
                        const std::string& original_token = "",
                        int option_style              = 0):
             invalid_syntax(kind, option_name, original_token, option_style) {}
-        ~invalid_command_line_syntax() throw() {}
+
+        ~invalid_command_line_syntax() throw() BOOST_OVERRIDE {}
     };
 
 
@@ -380,7 +380,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        ~validation_error() throw() {}
+        ~validation_error() throw() BOOST_OVERRIDE {}
 
         kind_t kind() const { return m_kind; }
 

--- a/include/boost/program_options/value_semantic.hpp
+++ b/include/boost/program_options/value_semantic.hpp
@@ -13,10 +13,10 @@
 #include <boost/function/function1.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <string>
-#include <vector>
-#include <typeinfo>
 #include <limits>
+#include <string>
+#include <typeinfo>
+#include <vector>
 
 namespace boost { namespace program_options {
 
@@ -92,7 +92,7 @@ namespace boost { namespace program_options {
     private: // base overrides
         void parse(boost::any& value_store, 
                    const std::vector<std::string>& new_tokens,
-                   bool utf8) const;
+                   bool utf8) const BOOST_OVERRIDE;
     protected: // interface for derived classes.
         virtual void xparse(boost::any& value_store, 
                             const std::vector<std::string>& new_tokens) 
@@ -112,7 +112,7 @@ namespace boost { namespace program_options {
     private: // base overrides
         void parse(boost::any& value_store, 
                    const std::vector<std::string>& new_tokens,
-                   bool utf8) const;
+                   bool utf8) const BOOST_OVERRIDE;
     protected: // interface for derived classes.
 #if !defined(BOOST_NO_STD_WSTRING)
         virtual void xparse(boost::any& value_store, 
@@ -130,14 +130,14 @@ namespace boost { namespace program_options {
         : m_zero_tokens(zero_tokens)
         {}
 
-        std::string name() const;
+        std::string name() const BOOST_OVERRIDE;
 
-        unsigned min_tokens() const;
-        unsigned max_tokens() const;
+        unsigned min_tokens() const BOOST_OVERRIDE;
+        unsigned max_tokens() const BOOST_OVERRIDE;
 
-        bool is_composing() const { return false; }
+        bool is_composing() const BOOST_OVERRIDE { return false; }
 
-        bool is_required() const { return false; }
+        bool is_required() const BOOST_OVERRIDE { return false; }
         
         /** If 'value_store' is already initialized, or new_tokens
             has more than one elements, throws. Otherwise, assigns
@@ -145,13 +145,13 @@ namespace boost { namespace program_options {
             any modifications.
          */
         void xparse(boost::any& value_store,
-                    const std::vector<std::string>& new_tokens) const;
+                    const std::vector<std::string>& new_tokens) const BOOST_OVERRIDE;
 
         /** Does nothing. */
-        bool apply_default(boost::any&) const { return false; }
+        bool apply_default(boost::any&) const BOOST_OVERRIDE { return false; }
 
         /** Does nothing. */
-        void notify(const boost::any&) const {}        
+        void notify(const boost::any&) const BOOST_OVERRIDE {}
     private:
         bool m_zero_tokens;
     };
@@ -299,11 +299,11 @@ namespace boost { namespace program_options {
 
     public: // value semantic overrides
 
-        std::string name() const;
+        std::string name() const BOOST_OVERRIDE;
 
-        bool is_composing() const { return m_composing; }
+        bool is_composing() const BOOST_OVERRIDE { return m_composing; }
 
-        unsigned min_tokens() const
+        unsigned min_tokens() const BOOST_OVERRIDE
         {
             if (m_zero_tokens || !m_implicit_value.empty()) {
                 return 0;
@@ -312,7 +312,8 @@ namespace boost { namespace program_options {
             }
         }
 
-        unsigned max_tokens() const {
+        unsigned max_tokens() const BOOST_OVERRIDE
+        {
             if (m_multitoken) {
                 return std::numeric_limits<unsigned>::max BOOST_PREVENT_MACRO_SUBSTITUTION();
             } else if (m_zero_tokens) {
@@ -322,19 +323,19 @@ namespace boost { namespace program_options {
             }
         }
 
-        bool is_required() const { return m_required; }
+        bool is_required() const BOOST_OVERRIDE { return m_required; }
 
         /** Creates an instance of the 'validator' class and calls
             its operator() to perform the actual conversion. */
         void xparse(boost::any& value_store, 
                     const std::vector< std::basic_string<charT> >& new_tokens) 
-            const;
+            const BOOST_OVERRIDE;
 
         /** If default value was specified via previous call to 
             'default_value', stores that value into 'value_store'.
             Returns true if default value was stored.
         */
-        virtual bool apply_default(boost::any& value_store) const
+        bool apply_default(boost::any& value_store) const BOOST_OVERRIDE
         {
             if (m_default_value.empty()) {
                 return false;
@@ -347,12 +348,12 @@ namespace boost { namespace program_options {
         /** If an address of variable to store value was specified
             when creating *this, stores the value there. Otherwise,
             does nothing. */
-        void notify(const boost::any& value_store) const;
+        void notify(const boost::any& value_store) const BOOST_OVERRIDE;
 
     public: // typed_value_base overrides
         
 #ifndef BOOST_NO_RTTI
-        const std::type_info& value_type() const
+        const std::type_info& value_type() const BOOST_OVERRIDE
         {
             return typeid(T);
         }
@@ -421,4 +422,3 @@ namespace boost { namespace program_options {
 #include "boost/program_options/detail/value_semantic.hpp"
 
 #endif
-

--- a/include/boost/program_options/variables_map.hpp
+++ b/include/boost/program_options/variables_map.hpp
@@ -12,9 +12,9 @@
 #include <boost/any.hpp>
 #include <boost/shared_ptr.hpp>
 
-#include <string>
 #include <map>
 #include <set>
+#include <string>
 
 #if defined(BOOST_MSVC)
 #   pragma warning (push)
@@ -162,7 +162,7 @@ namespace boost { namespace program_options {
     private:
         /** Implementation of abstract_variables_map::get
             which does 'find' in *this. */
-        const variable_value& get(const std::string& name) const;
+        const variable_value& get(const std::string& name) const BOOST_OVERRIDE;
 
         /** Names of option with 'final' values \-- which should not
             be changed by subsequence assignments. */

--- a/src/cmdline.cpp
+++ b/src/cmdline.cpp
@@ -17,17 +17,15 @@
 
 #include <boost/bind/bind.hpp>
 
+#include <cassert>
+#include <cctype>
+#include <climits>
+#include <cstdio>
+#include <cstring>
+#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
-#include <cassert>
-#include <cstring>
-#include <cctype>
-#include <climits>
-
-#include <cstdio>
-
-#include <iostream>
 
 using namespace boost::placeholders;
 
@@ -210,7 +208,7 @@ namespace boost { namespace program_options { namespace detail {
         // of unparsed tokens and can consume some of them (by
         // removing elements on front) and return a vector of options.
         //
-        // We try each style parser in turn, untill some input
+        // We try each style parser in turn, until some input
         // is consumed. The returned vector of option may contain the
         // result of just syntactic parsing of token, say --foo will
         // be parsed as option with name 'foo', and the style parser
@@ -407,7 +405,7 @@ namespace boost { namespace program_options { namespace detail {
         // Be defensive:
         // will have no original token if option created by handle_additional_parser()
         std::string original_token_for_exceptions = opt.string_key;
-        if (opt.original_tokens.size())
+        if (!opt.original_tokens.empty())
             original_token_for_exceptions = opt.original_tokens[0];
 
         try

--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -3,13 +3,12 @@
 // (See accompanying file LICENSE_1_0.txt
 // or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <clocale>
 #include <fstream>
-#include <locale.h>
 #include <locale>
 #include <iostream>
-#include <string>
-#include <locale>
 #include <stdexcept>
+#include <string>
 
 #include <boost/config.hpp>
 

--- a/src/options_description.cpp
+++ b/src/options_description.cpp
@@ -20,10 +20,11 @@
 
 #include <cassert>
 #include <climits>
-#include <cstring>
 #include <cstdarg>
-#include <sstream>
+#include <cstring>
 #include <iterator>
+#include <sstream>
+#include <string>
 using namespace std;
 
 namespace boost { namespace program_options {
@@ -127,7 +128,7 @@ namespace boost { namespace program_options {
     const std::string& 
     option_description::key(const std::string& option) const
     {
-        // We make the arbitrary choise of using the first long
+        // We make the arbitrary choice of using the first long
         // name as the key, regardless of anything else
         if (!m_long_names.empty()) {
             const std::string& first_long_name = *m_long_names.begin();
@@ -174,7 +175,7 @@ namespace boost { namespace program_options {
     const std::string&
     option_description::long_name() const
     {
-        static std::string empty_string("");
+        static std::string empty_string;
         return m_long_names.empty() ? empty_string : *m_long_names.begin();
     }
 
@@ -443,7 +444,7 @@ namespace boost { namespace program_options {
             line_length -= indent;
 
             // index of tab (if present) is used as additional indent relative
-            // to first_column_width if paragrapth is spanned over multiple
+            // to first_column_width if paragraph is spanned over multiple
             // lines if tab is not on first line it is ignored
             string::size_type par_indent = par.find('\t');
 
@@ -492,7 +493,7 @@ namespace boost { namespace program_options {
                         // If line starts with space, but second character
                         // is not space, remove the leading space.
                         // We don't remove double spaces because those
-                        // might be intentianal.
+                        // might be intentional.
                         if ((*line_begin == ' ') &&
                             ((line_begin + 1 < par_end) &&
                              (*(line_begin + 1) != ' ')))

--- a/src/variables_map.cpp
+++ b/src/variables_map.cpp
@@ -12,6 +12,9 @@
 #include <boost/program_options/variables_map.hpp>
 
 #include <cassert>
+#include <map>
+#include <set>
+#include <string>
 
 namespace boost { namespace program_options {
 
@@ -67,8 +70,8 @@ namespace boost { namespace program_options {
                 if (xm.m_final.count(option_name))
                     continue;
 
-                original_token = options.options[i].original_tokens.size() ?
-                                        options.options[i].original_tokens[0]     : "";
+                original_token = options.options[i].original_tokens.empty() ?
+                                        "" : options.options[i].original_tokens[0];
                 const option_description& d = desc.find(option_name, false,
                                                         false, false);
 


### PR DESCRIPTION
Use BOOST_OVERRIDE to fix GCC -Wsuggest-override and Clang-tidy modernize-use-override warnings.
Also fix Clang-tidy modernize-deprecated-headers, readability-container-size-empty and readability-redundant-string-init warnings.
Alphabetical order of STL headers. Add missing STL headers.
Fix spelling mistakes.