### PR TITLE
Allow use of std::optional for optional arguments

### DIFF
--- a/include/boost/program_options/detail/value_semantic.hpp
+++ b/include/boost/program_options/detail/value_semantic.hpp
@@ -169,6 +169,20 @@ namespace boost { namespace program_options {
         v = boost::any(boost::optional<T>(boost::any_cast<T>(a)));
     }
 
+    /** Validates optional arguments. */
+    template<class T, class charT>
+    void validate(boost::any& v,
+                  const std::vector<std::basic_string<charT> >& s,
+                  std::optional<T>*,
+                  int)
+    {
+        validators::check_first_occurrence(v);
+        validators::get_single_string(s);
+        boost::any a;
+        validate(a, s, (T*)0, 0);
+        v = boost::any(std::optional<T>(boost::any_cast<T>(a)));
+    }
+
     template<class T, class charT>
     void 
     typed_value<T, charT>::


### PR DESCRIPTION
This is in addition to supporting boost::optional.