### PR TITLE
Mention option name in unknown_option exception

### DIFF
--- a/src/options_description.cpp
+++ b/src/options_description.cpp
@@ -352,7 +352,7 @@ namespace boost { namespace program_options {
         const option_description* d = find_nothrow(name, approx, 
                                        long_ignore_case, short_ignore_case);
         if (!d)
-            boost::throw_exception(unknown_option());
+            boost::throw_exception(unknown_option(name));
         return *d;
     }
 


### PR DESCRIPTION
Shouldn't it be like this?