### PR TITLE
Use BOOST_DEFAULTED_FUNCTION on empty destructors

### DIFF
--- a/include/boost/program_options/detail/config_file.hpp
+++ b/include/boost/program_options/detail/config_file.hpp
@@ -76,7 +76,7 @@ namespace boost { namespace program_options { namespace detail {
             const std::set<std::string>& allowed_options,
             bool allow_unregistered = false);
 
-        virtual ~common_config_file_iterator() {}
+        BOOST_DEFAULTED_FUNCTION(virtual ~common_config_file_iterator(), {})
 
     public: // Method required by eof_iterator
         

--- a/include/boost/program_options/errors.hpp
+++ b/include/boost/program_options/errors.hpp
@@ -121,7 +121,7 @@ namespace boost { namespace program_options {
         /** gcc says that throw specification on dtor is loosened 
          *  without this line                                     
          *  */ 
-        ~error_with_option_name() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~error_with_option_name() throw(), {})
 
 
         //void dump() const
@@ -209,7 +209,7 @@ namespace boost { namespace program_options {
         multiple_values() 
          : error_with_option_name("option '%canonical_option%' only takes a single argument"){}
 
-        ~multiple_values() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~multiple_values() throw(), {})
     };
 
     /** Class thrown when there are several occurrences of an
@@ -220,7 +220,7 @@ namespace boost { namespace program_options {
         multiple_occurrences() 
          : error_with_option_name("option '%canonical_option%' cannot be specified more than once"){}
 
-        ~multiple_occurrences() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~multiple_occurrences() throw(), {})
 
     };
 
@@ -233,7 +233,7 @@ namespace boost { namespace program_options {
        {
        }
 
-       ~required_option() throw() {}
+       BOOST_DEFAULTED_FUNCTION(~required_option() throw(), {})
     };
 
     /** Base class of unparsable options,
@@ -258,7 +258,7 @@ namespace boost { namespace program_options {
         /** Does NOT set option name, because no option name makes sense */
         virtual void set_option_name(const std::string&) {}
 
-        ~error_with_no_option_name() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~error_with_no_option_name() throw(), {})
     };
 
 
@@ -270,7 +270,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        ~unknown_option() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~unknown_option() throw(), {})
     };
 
 
@@ -283,7 +283,7 @@ namespace boost { namespace program_options {
             m_alternatives(xalternatives)
         {}
 
-        ~ambiguous_option() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~ambiguous_option() throw(), {})
 
         const std::vector<std::string>& alternatives() const throw() {return m_alternatives;}
 
@@ -320,7 +320,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        ~invalid_syntax() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~invalid_syntax() throw(), {})
 
         kind_t kind() const {return m_kind;}
 
@@ -340,7 +340,7 @@ namespace boost { namespace program_options {
             m_substitutions["invalid_line"] = invalid_line;
         }
 
-        ~invalid_config_file_syntax() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~invalid_config_file_syntax() throw(), {})
 
         /** Convenience functions for backwards compatibility */
         virtual std::string tokens() const {return m_substitutions.find("invalid_line")->second;    }
@@ -355,7 +355,7 @@ namespace boost { namespace program_options {
                        const std::string& original_token = "",
                        int option_style              = 0):
             invalid_syntax(kind, option_name, original_token, option_style) {}
-        ~invalid_command_line_syntax() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~invalid_command_line_syntax() throw(), {})
     };
 
 
@@ -380,7 +380,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        ~validation_error() throw() {}
+        BOOST_DEFAULTED_FUNCTION(~validation_error() throw(), {})
 
         kind_t kind() const { return m_kind; }
 


### PR DESCRIPTION
The compiler-generated copy constructor and copy assignment operator are deprecated since C++11 on classes with user-declared destructors.

This change allows clean compilation with the -Wdeprecated-copy-dtor/-Wdeprecated-copy-with-user-provided-dtor flag.