### PR TITLE
Fix unininitialized member in common_config_file_iterator

### DIFF
--- a/include/boost/program_options/detail/config_file.hpp
+++ b/include/boost/program_options/detail/config_file.hpp
@@ -71,7 +71,10 @@ namespace boost { namespace program_options { namespace detail {
         : public eof_iterator<common_config_file_iterator, option>
     {
     public:
-        common_config_file_iterator() { found_eof(); }
+        common_config_file_iterator() {
+            allow_unregistered = false
+            found_eof();
+        }
         common_config_file_iterator(
             const std::set<std::string>& allowed_options,
             bool allow_unregistered = false);


### PR DESCRIPTION
Invoking default constructor of `common_config_file_iterator` leads to `allow_unregistered` being left uninitialized.

Issue was discovered by running ASan build on Centos 7.
g++ (GCC) 12.3.0


``` /tmp/cmake-build-docker-asan/_deps/boost-src/libs/program_options/include/boost/program_options/detail/config_file.hpp:70:38: runtime error: load of value 12, which is not a valid value for type 'bool'
pc_0x7f4142559d76###func_boost::program_options::detail::common_config_file_iterator::common_config_file_iterator(boost::program_options::detail::common_config_file_iterator const&)###file_/tmp/cmake-build-docker-asan/_deps/boost-src/libs/program_options/include/boost/program_options/detail/config_file.hpp###line_70###obj_(libboost_program_options.so.1.84.0+0x559d76)
pc_0x7f414255a20f###func_boost::program_options::detail::basic_config_file_iterator<char>::basic_config_file_iterator(boost::program_options::detail::basic_config_file_iterator<char> const&)###file_/tmp/cmake-build-docker-asan/_deps/boost-src/libs/program_options/include/boost/program_options/detail/config_file.hpp###line_119###obj_(libboost_program_options.so.1.84.0+0x55a20f)
pc_0x7f414255a5cb###func_std::back_insert_iterator<std::vector<boost::program_options::basic_option<char>, std::allocator<boost::program_options::basic_option<char> > > > std::copy<boost::program_options::detail::basic_config_file_iterator<char>, std::back_insert_iterator<std::vector<boost::program_options::basic_option<char>, std::allocator<boost::program_options::basic_option<char> > > > >(boost::program_options::detail::basic_config_file_iterator<char>, boost::program_options::detail::basic_config_file_iterator<char>, std::back_insert_iterator<std::vector<boost::program_options::basic_option<char>, std::allocator<boost::program_options::basic_option<char> > > >)###file_/tools/include/c++/12.2.0/bits/stl_algobase.h###line_620###obj_(libboost_program_options.so.1.84.0+0x55a5cb)
pc_0x7f4142550bbc###func_boost::program_options::basic_parsed_options<char> boost::program_options::parse_config_file<char>(std::basic_istream<char, std::char_traits<char> >&, boost::program_options::options_description const&, bool)###file_<null>###line_0###obj_(libboost_program_options.so.1.84.0+0x550bbc)
.
.
.

AddressSanitizer:DEADLYSIGNAL
 ```