### PR TITLE
Fix C++20 incompatibility from using exception specifications

### DIFF
--- a/include/boost/program_options/errors.hpp
+++ b/include/boost/program_options/errors.hpp
@@ -121,7 +121,7 @@ namespace boost { namespace program_options {
         /** gcc says that throw specification on dtor is loosened 
          *  without this line                                     
          *  */ 
-        BOOST_DEFAULTED_FUNCTION(~error_with_option_name() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~error_with_option_name() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
 
         //void dump() const
@@ -183,7 +183,7 @@ namespace boost { namespace program_options {
 
         /** Creates the error_message on the fly
          *      Currently a thin wrapper for substitute_placeholders() */
-        virtual const char* what() const throw();
+        virtual const char* what() const BOOST_NOEXCEPT_OR_NOTHROW;
 
     protected:
         /** Used to hold the error text returned by what() */
@@ -209,7 +209,7 @@ namespace boost { namespace program_options {
         multiple_values() 
          : error_with_option_name("option '%canonical_option%' only takes a single argument"){}
 
-        BOOST_DEFAULTED_FUNCTION(~multiple_values() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~multiple_values() BOOST_NOEXCEPT_OR_NOTHROW, {})
     };
 
     /** Class thrown when there are several occurrences of an
@@ -220,7 +220,7 @@ namespace boost { namespace program_options {
         multiple_occurrences() 
          : error_with_option_name("option '%canonical_option%' cannot be specified more than once"){}
 
-        BOOST_DEFAULTED_FUNCTION(~multiple_occurrences() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~multiple_occurrences() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
     };
 
@@ -233,7 +233,7 @@ namespace boost { namespace program_options {
        {
        }
 
-       BOOST_DEFAULTED_FUNCTION(~required_option() throw(), {})
+       BOOST_DEFAULTED_FUNCTION(~required_option() BOOST_NOEXCEPT_OR_NOTHROW, {})
     };
 
     /** Base class of unparsable options,
@@ -258,7 +258,7 @@ namespace boost { namespace program_options {
         /** Does NOT set option name, because no option name makes sense */
         virtual void set_option_name(const std::string&) {}
 
-        BOOST_DEFAULTED_FUNCTION(~error_with_no_option_name() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~error_with_no_option_name() BOOST_NOEXCEPT_OR_NOTHROW, {})
     };
 
 
@@ -270,7 +270,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        BOOST_DEFAULTED_FUNCTION(~unknown_option() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~unknown_option() BOOST_NOEXCEPT_OR_NOTHROW, {})
     };
 
 
@@ -283,9 +283,9 @@ namespace boost { namespace program_options {
             m_alternatives(xalternatives)
         {}
 
-        BOOST_DEFAULTED_FUNCTION(~ambiguous_option() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~ambiguous_option() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
-        const std::vector<std::string>& alternatives() const throw() {return m_alternatives;}
+        const std::vector<std::string>& alternatives() const BOOST_NOEXCEPT_OR_NOTHROW {return m_alternatives;}
 
     protected:
         /** Makes all substitutions using the template */
@@ -320,7 +320,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        BOOST_DEFAULTED_FUNCTION(~invalid_syntax() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~invalid_syntax() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
         kind_t kind() const {return m_kind;}
 
@@ -340,7 +340,7 @@ namespace boost { namespace program_options {
             m_substitutions["invalid_line"] = invalid_line;
         }
 
-        BOOST_DEFAULTED_FUNCTION(~invalid_config_file_syntax() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~invalid_config_file_syntax() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
         /** Convenience functions for backwards compatibility */
         virtual std::string tokens() const {return m_substitutions.find("invalid_line")->second;    }
@@ -355,7 +355,7 @@ namespace boost { namespace program_options {
                        const std::string& original_token = "",
                        int option_style              = 0):
             invalid_syntax(kind, option_name, original_token, option_style) {}
-        BOOST_DEFAULTED_FUNCTION(~invalid_command_line_syntax() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~invalid_command_line_syntax() BOOST_NOEXCEPT_OR_NOTHROW, {})
     };
 
 
@@ -380,7 +380,7 @@ namespace boost { namespace program_options {
         {
         }
 
-        BOOST_DEFAULTED_FUNCTION(~validation_error() throw(), {})
+        BOOST_DEFAULTED_FUNCTION(~validation_error() BOOST_NOEXCEPT_OR_NOTHROW, {})
 
         kind_t kind() const { return m_kind; }
 

--- a/src/value_semantic.cpp
+++ b/src/value_semantic.cpp
@@ -260,7 +260,7 @@ namespace boost { namespace program_options {
     }
 
 
-    const char* error_with_option_name::what() const throw()
+    const char* error_with_option_name::what() const BOOST_NOEXCEPT_OR_NOTHROW
     {
         // will substitute tokens each time what is run()
         substitute_placeholders(m_error_template);


### PR DESCRIPTION
C++20 removed support for exception specifications, so at least clang-19 is now emitting errors on them. Replaced exception specifications with `BOOST_NOEXCEPT_OR_NOTHROW`, which converts `throw()` to `noexcept`, but keeps the code formally compatible with C++03.

This has been brought up during Boost 1.85.0 release preparation.

This PR is similar to the following PRs, and once this one or one of those is merged, the others can be closed:

https://github.com/boostorg/program_options/pull/118 - this PR is similar to that one, but resolves merge conflicts.
https://github.com/boostorg/program_options/pull/129 - unlike that PR, this one does not remove exception specifications from destructors, which keeps the code formally compatible with C++03.

This PR also updates GitHub Actions config to fix CI failures on clang-13 through 15 due to their incompatibility with libstdc++-13 in C++23 mode. (The failures are unrelated to this PR.)
