### PR TITLE
avoid potential null dereferences

### DIFF
--- a/include/boost/program_options/detail/value_semantic.hpp
+++ b/include/boost/program_options/detail/value_semantic.hpp
@@ -42,10 +42,10 @@ namespace boost { namespace program_options {
     typed_value<T, charT>::notify(const boost::any& value_store) const
     {
         const T* value = boost::any_cast<T>(&value_store);
-        if (m_store_to) {
+        if (m_store_to && value) {
             *m_store_to = *value;
         }
-        if (m_notifier) {
+        if (m_notifier && value) {
             m_notifier(*value);
         }
     }


### PR DESCRIPTION
with some warnings enabled, gcc 13 and above detect a potential null pointer dereference in the `typed_value::notify` member function.